### PR TITLE
Update to use makeQuery for compatability with Fluent 2.0 beta 8

### DIFF
--- a/Sources/Authentication/Authenticatable/PasswordAuthenticatable.swift
+++ b/Sources/Authentication/Authenticatable/PasswordAuthenticatable.swift
@@ -57,7 +57,7 @@ extension PasswordAuthenticatable where Self: Entity {
         
         if let verifier = passwordVerifier {
             guard let match = try Self
-                .query()
+                .makeQuery()
                 .filter(usernameKey, creds.username)
                 .first()
                 else {
@@ -78,7 +78,7 @@ extension PasswordAuthenticatable where Self: Entity {
             user = match
         } else {
             guard let match = try Self
-                .query()
+                .makeQuery()
                 .filter(usernameKey, creds.username)
                 .filter(passwordKey, creds.password)
                 .first()

--- a/Sources/Authentication/Authenticatable/TokenAuthenticatable.swift
+++ b/Sources/Authentication/Authenticatable/TokenAuthenticatable.swift
@@ -22,7 +22,7 @@ import Fluent
 
 extension TokenAuthenticatable where Self: Entity, Self.TokenType: Entity {
     public static func authenticate(_ token: Token) throws -> Self {
-        guard let user = try Self.query()
+        guard let user = try Self.makeQuery()
             .join(Self.TokenType.self)
             .filter(Self.TokenType.self, tokenKey, token.string)
             .first()
@@ -36,7 +36,7 @@ extension TokenAuthenticatable where Self: Entity, Self.TokenType: Entity {
 
 extension TokenAuthenticatable where Self: Entity, Self.TokenType: Entity, Self.TokenType == Self {
     public static func authenticate(_ token: Token) throws -> Self {
-        guard let user = try Self.query()
+        guard let user = try Self.makeQuery()
             .filter(tokenKey, token.string)
             .first()
             else {

--- a/Sources/Authorization/Authorizable.swift
+++ b/Sources/Authorization/Authorizable.swift
@@ -16,7 +16,7 @@ extension Authorizable {
             PivotType.Left == Self,
             PivotType.Right == PermissionType
     {
-        guard let permission = try PermissionType.query().filter("key", permission.key).first() else {
+        guard let permission = try PermissionType.makeQuery().filter("key", permission.key).first() else {
             throw AuthorizationError.unknownPermission
         }
 
@@ -50,7 +50,7 @@ extension PivotProtocol where Self.Right: Permission {
     
     public static func add(_ permission: Self.Right, to left: Self.Left) throws {
         guard let permission = try Self.Right
-            .query()
+            .makeQuery()
             .filter("key", permission.key)
             .first()
         else {
@@ -80,7 +80,7 @@ extension Authorizable {
             PivotType.Left.Right == MiddleType,
             PivotType.Right == PermissionType
     {
-        guard let permission = try PermissionType.query().filter("key", permission.key).first() else {
+        guard let permission = try PermissionType.makeQuery().filter("key", permission.key).first() else {
             throw AuthorizationError.unknownPermission
         }
 


### PR DESCRIPTION
This fixes incompatability with Fluent 2.0 beta 8 where the `query` method on `Entity` has been renamed to `makeQuery`.