### PR TITLE
Proposal: Change signature of PasswordVerifier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 /Packages
 /*.xcodeproj
 Package.pins
+DerivedData/
 

--- a/Sources/Authentication/Authenticatable/PasswordAuthenticatable.swift
+++ b/Sources/Authentication/Authenticatable/PasswordAuthenticatable.swift
@@ -44,7 +44,7 @@ extension PasswordAuthenticatable {
 
 
 public protocol PasswordVerifier {
-    func verify(password: String, matchesHash: String) throws -> Bool
+    func verify(password: String, matches hash: String) throws -> Bool
 }
 
 // MARK: Entity conformance
@@ -70,7 +70,7 @@ extension PasswordAuthenticatable where Self: Entity {
             
             guard try verifier.verify(
                 password: creds.password,
-                matchesHash: hash
+                matches: hash
                 ) else {
                     throw AuthenticationError.invalidCredentials
             }

--- a/Sources/Authentication/Authenticatable/PasswordAuthenticatable.swift
+++ b/Sources/Authentication/Authenticatable/PasswordAuthenticatable.swift
@@ -1,3 +1,5 @@
+import Bits
+
 public protocol PasswordAuthenticatable: Authenticatable {
     // MARK:  Username / Password
     /// Return the user matching the supplied
@@ -44,7 +46,15 @@ extension PasswordAuthenticatable {
 
 
 public protocol PasswordVerifier {
-    func verify(password: String, matches hash: String) throws -> Bool
+    func verify(password: Bytes, matches hash: Bytes) throws -> Bool
+}
+
+extension PasswordVerifier {
+    public func verify(password: BytesConvertible, matches hash: BytesConvertible) throws -> Bool {
+        let password = try password.makeBytes()
+        let hash = try hash.makeBytes()
+        return try verify(password: password, matches: hash)
+    }
 }
 
 // MARK: Entity conformance
@@ -69,8 +79,8 @@ extension PasswordAuthenticatable where Self: Entity {
             }
             
             guard try verifier.verify(
-                password: creds.password,
-                matches: hash
+                password: creds.password.makeBytes(),
+                matches: hash.makeBytes()
                 ) else {
                     throw AuthenticationError.invalidCredentials
             }


### PR DESCRIPTION
**This contains a breaking API change**

This PR changes the signature of the `PasswordVerifier` protocol to make it nicer to call when creating some that implements it.

For example, previously with BCrypt your call would look like:

```swift
public func verify(password: String, matchesHash: String) throws -> Bool {
    return try check(password.bytes, matchesHash: matchesHash.bytes)
}
```

This would change it to:

```swift
public func verify(password: String, matches hash: String) throws -> Bool {
    return try check(password.bytes, matches: hash.bytes)
}
```

This reads a bit nicer. I've also considered changing it to `func verify(password: String, matchesHash hash: String) throws -> Bool` but I thought I would throw it out there to see what people's thoughts are!