### PR TITLE
Add AuthorizationHeader initializers for Basic and Bearer

### DIFF
--- a/Sources/Authentication/Header/Basic.swift
+++ b/Sources/Authentication/Header/Basic.swift
@@ -1,21 +1,25 @@
-import Core
-
 extension AuthorizationHeader {
     public var basic: Password? {
         guard let range = string.range(of: "Basic ") else {
             return nil
         }
-
+        
         let token = string.substring(from: range.upperBound)
-
+        
         let decodedToken = token.makeBytes().base64Decoded.makeString()
         guard let separatorRange = decodedToken.range(of: ":") else {
             return nil
         }
-
+        
         let username = decodedToken.substring(to: separatorRange.lowerBound)
         let password = decodedToken.substring(from: separatorRange.upperBound)
-
+        
         return Password(username: username, password: password)
+    }
+    
+    public init(basic: Password) {
+        let credentials = "\(basic.username):\(basic.password)"
+        let encoded = credentials.makeBytes().base64Encoded.makeString()
+        self.init(string: "Basic \(encoded)")
     }
 }

--- a/Sources/Authentication/Header/Basic.swift
+++ b/Sources/Authentication/Header/Basic.swift
@@ -3,20 +3,20 @@ extension AuthorizationHeader {
         guard let range = string.range(of: "Basic ") else {
             return nil
         }
-        
+
         let token = string.substring(from: range.upperBound)
-        
+
         let decodedToken = token.makeBytes().base64Decoded.makeString()
         guard let separatorRange = decodedToken.range(of: ":") else {
             return nil
         }
-        
+
         let username = decodedToken.substring(to: separatorRange.lowerBound)
         let password = decodedToken.substring(from: separatorRange.upperBound)
-        
+
         return Password(username: username, password: password)
     }
-    
+
     public init(basic: Password) {
         let credentials = "\(basic.username):\(basic.password)"
         let encoded = credentials.makeBytes().base64Encoded.makeString()

--- a/Sources/Authentication/Header/Bearer.swift
+++ b/Sources/Authentication/Header/Bearer.swift
@@ -3,8 +3,12 @@ extension AuthorizationHeader {
         guard let range = string.range(of: "Bearer ") else {
             return nil
         }
-
+        
         let token = string.substring(from: range.upperBound)
         return Token(string: token)
+    }
+    
+    public init(bearer: Token) {
+        self.init(string: "Bearer \(bearer.string)")
     }
 }

--- a/Sources/Authentication/Header/Bearer.swift
+++ b/Sources/Authentication/Header/Bearer.swift
@@ -3,11 +3,11 @@ extension AuthorizationHeader {
         guard let range = string.range(of: "Bearer ") else {
             return nil
         }
-        
+
         let token = string.substring(from: range.upperBound)
         return Token(string: token)
     }
-    
+
     public init(bearer: Token) {
         self.init(string: "Bearer \(bearer.string)")
     }


### PR DESCRIPTION
These are initializers to make setting AuthorizationHeader in a request easier & safer.

This is related to this enhancement proposition: https://github.com/vapor/engine/issues/147

But i've rethought my proposition and i think making these initializers along with making request.auth.header settable in AuthProvider is cleaner. This is what can be done now:

```swift
let credentials = Password(username: username, password: password)
req.auth.header = AuthorizationHeader(basic: credentials)
```

[Pull Request in vapor/auth-provider](https://github.com/vapor/auth-provider/pull/17)