### PR TITLE
In Swift 4, extracting the username was including the separator

### DIFF
--- a/Sources/Authentication/Header/Basic.swift
+++ b/Sources/Authentication/Header/Basic.swift
@@ -12,7 +12,7 @@ extension AuthorizationHeader {
                 return nil
             }
 
-            let username = decodedToken[...separatorRange.lowerBound]
+            let username = decodedToken[..<separatorRange.lowerBound]
             let password = decodedToken[separatorRange.upperBound...]
 
             return Password(username: String(username), password: String(password))


### PR DESCRIPTION
The Basic auth was broken in Swift 4 because the username extracted from the header was including the `:` separator. Fixed by using the exclusive range operator instead of the inclusive one.