### PR TITLE
Bypass config for PasswordAuthenticatable and make tests compile

### DIFF
--- a/Sources/Authentication/PasswordAuthenticatable.swift
+++ b/Sources/Authentication/PasswordAuthenticatable.swift
@@ -7,16 +7,18 @@ import Vapor
 public protocol PasswordAuthenticatable: BasicAuthenticatable { }
 
 extension PasswordAuthenticatable where Database: QuerySupporting {
-    /// Authenticates using a username and password on the supplied connection.
+    /// Authenticates using a username and password using the supplied
+    // verifier on the supplied connection.
     public static func authenticate(
         username: String,
         password: String,
-        on worker: DatabaseConnectable & Container
-    ) -> Future<Self?> {
+        using verifier: PasswordVerifier,
+        on worker: DatabaseConnectable
+        ) -> Future<Self?> {
         return Future {
-            return try Self.authenticate(
+            return Self.authenticate(
                 using: .init(username: username, password: password),
-                verifier: worker.make(PasswordVerifier.self, for: Self.self),
+                verifier: verifier,
                 on: worker
             )
         }

--- a/Tests/AuthenticationTests/AuthenticationTests.swift
+++ b/Tests/AuthenticationTests/AuthenticationTests.swift
@@ -63,7 +63,6 @@ class AuthenticationTests: XCTestCase {
 
     func testSessionPersist() throws {
         var services = Services.default()
-        try services.register(FluentProvider())
         try services.register(FluentSQLiteProvider())
         try services.register(AuthenticationProvider())
 
@@ -80,7 +79,10 @@ class AuthenticationTests: XCTestCase {
         middleware.use(SessionsMiddleware.self)
         services.register(middleware)
 
-        let app = try Application(services: services)
+        var config = Config.default()
+        config.prefer(MemoryKeyedCache.self, for: KeyedCache.self)
+
+        let app = try Application(config: config, services: services)
 
         let conn = try app.requestConnection(to: .test).blockingAwait()
         defer { app.releaseConnection(conn, to: .test) }

--- a/Tests/AuthenticationTests/AuthenticationTests.swift
+++ b/Tests/AuthenticationTests/AuthenticationTests.swift
@@ -6,14 +6,14 @@ import XCTest
 
 class AuthenticationTests: XCTestCase {
     func testPassword() throws {
-        let queue = DispatchEventLoop(label: "test.auth")
+        let queue = try DefaultEventLoop(label: "test.auth")
         
-        let database = SQLiteDatabase(storage: .memory)
+        let database = try SQLiteDatabase(storage: .memory)
         let conn = try database.makeConnection(on: queue).blockingAwait()
 
         try User.prepare(on: conn).blockingAwait()
         let user = User(name: "Tanner", email: "tanner@vapor.codes", password: "foo")
-        try user.save(on: conn).blockingAwait()
+        _ = try user.save(on: conn).blockingAwait()
 
         let password = BasicAuthorization(username: "tanner@vapor.codes", password: "foo")
         let authed = try User.authenticate(using: password, verifier: PlaintextVerifier(), on: conn).blockingAwait()
@@ -23,10 +23,10 @@ class AuthenticationTests: XCTestCase {
     func testApplication() throws {
         var services = Services.default()
         try services.register(FluentProvider())
-        try services.register(SQLiteProvider())
+        try services.register(FluentSQLiteProvider())
         try services.register(AuthenticationProvider())
 
-        let sqlite = SQLiteDatabase(storage: .memory)
+        let sqlite = try SQLiteDatabase(storage: .memory)
         var databases = DatabaseConfig()
         databases.add(database: sqlite, as: .test)
         services.register(databases)
@@ -41,7 +41,7 @@ class AuthenticationTests: XCTestCase {
         defer { app.releaseConnection(conn, to: .test) }
 
         let user = User(name: "Tanner", email: "tanner@vapor.codes", password: "foo")
-        try user.save(on: conn).blockingAwait()
+        _ = try user.save(on: conn).blockingAwait()
 
         let router = try app.make(Router.self)
 
@@ -60,16 +60,16 @@ class AuthenticationTests: XCTestCase {
         let responder = try app.make(Responder.self)
         let res = try responder.respond(to: req).blockingAwait()
         XCTAssertEqual(res.http.status, .ok)
-        XCTAssertEqual(res.http.body.data, Data("Tanner".utf8))
+        XCTAssertEqual(try res.http.body.makeData(max: 10).blockingAwait(), Data("Tanner".utf8))
     }
 
     func testSessionPersist() throws {
         var services = Services.default()
         try services.register(FluentProvider())
-        try services.register(SQLiteProvider())
+        try services.register(FluentSQLiteProvider())
         try services.register(AuthenticationProvider())
 
-        let sqlite = SQLiteDatabase(storage: .memory)
+        let sqlite = try SQLiteDatabase(storage: .memory)
         var databases = DatabaseConfig()
         databases.add(database: sqlite, as: .test)
         services.register(databases)
@@ -88,7 +88,7 @@ class AuthenticationTests: XCTestCase {
         defer { app.releaseConnection(conn, to: .test) }
 
         let user = User(name: "Tanner", email: "tanner@vapor.codes", password: "foo")
-        try user.save(on: conn).blockingAwait()
+        _ = try user.save(on: conn).blockingAwait()
 
         let router = try app.make(Router.self)
 
@@ -124,7 +124,7 @@ class AuthenticationTests: XCTestCase {
 
             let res = try responder.respond(to: req).blockingAwait()
             XCTAssertEqual(res.http.status, .ok)
-            XCTAssertEqual(res.http.body.data, Data("Tanner".utf8))
+            XCTAssertEqual(try res.http.body.makeData(max: 10).blockingAwait(), Data("Tanner".utf8))
             session = String(res.headers[.setCookie]!.split(separator: ";").first!)
         }
 
@@ -138,7 +138,7 @@ class AuthenticationTests: XCTestCase {
 
             let res = try responder.respond(to: req).blockingAwait()
             XCTAssertEqual(res.http.status, .ok)
-            XCTAssertEqual(res.http.body.data, Data("Tanner".utf8))
+            XCTAssertEqual(try res.http.body.makeData(max: 10).blockingAwait(), Data("Tanner".utf8))
         }
 
         /// persisted, no-session req


### PR DESCRIPTION
Bypasses the need to specify the verifier in config and allows it to be passed into the `authenticate` call directly to allow for better flexibility for use cases such as libraries as per discussion on Slack.