### PR TITLE
Move the password hashing logic

### DIFF
--- a/Sources/Authentication/Authenticatable/PasswordAuthenticatable.swift
+++ b/Sources/Authentication/Authenticatable/PasswordAuthenticatable.swift
@@ -66,16 +66,16 @@ extension PasswordAuthenticatable where Self: Entity {
         let user: Self
         
         if let verifier = passwordVerifier {
+            guard let hash = match.hashedPassword else {
+                throw AuthenticationError.invalidCredentials
+            }
+            
             guard let match = try Self
                 .makeQuery()
                 .filter(usernameKey, creds.username)
                 .first()
                 else {
                     throw AuthenticationError.invalidCredentials
-            }
-            
-            guard let hash = match.hashedPassword else {
-                throw AuthenticationError.invalidCredentials
             }
             
             guard try verifier.verify(

--- a/Sources/Authentication/Authenticatable/PasswordAuthenticatable.swift
+++ b/Sources/Authentication/Authenticatable/PasswordAuthenticatable.swift
@@ -75,9 +75,10 @@ extension PasswordAuthenticatable where Self: Entity {
             guard try verifier.verify(
                 password: creds.password.makeBytes(),
                 matches: expectedPasswordHash.makeBytes()
-                ), user = match else {
+                ), let matchedUser = match else {
                     throw AuthenticationError.invalidCredentials
             }
+            user = matchedUser
         } else {
             guard let match = try Self
                 .makeQuery()

--- a/Sources/Authentication/Authenticatable/PasswordAuthenticatable.swift
+++ b/Sources/Authentication/Authenticatable/PasswordAuthenticatable.swift
@@ -66,26 +66,18 @@ extension PasswordAuthenticatable where Self: Entity {
         let user: Self
         
         if let verifier = passwordVerifier {
-            guard let hash = match.hashedPassword else {
-                throw AuthenticationError.invalidCredentials
-            }
-            
-            guard let match = try Self
+            let match = try Self
                 .makeQuery()
                 .filter(usernameKey, creds.username)
                 .first()
-                else {
-                    throw AuthenticationError.invalidCredentials
-            }
+            let expectedPasswordHash = match?.hashedPassword ?? ""
             
             guard try verifier.verify(
                 password: creds.password.makeBytes(),
-                matches: hash.makeBytes()
-                ) else {
+                matches: expectedPasswordHash.makeBytes()
+                ), user = match else {
                     throw AuthenticationError.invalidCredentials
             }
-            
-            user = match
         } else {
             guard let match = try Self
                 .makeQuery()

--- a/Sources/Authentication/Authenticatable/PasswordAuthenticatable.swift
+++ b/Sources/Authentication/Authenticatable/PasswordAuthenticatable.swift
@@ -70,14 +70,16 @@ extension PasswordAuthenticatable where Self: Entity {
                 .makeQuery()
                 .filter(usernameKey, creds.username)
                 .first()
-            let expectedPasswordHash = match?.hashedPassword ?? ""
-            
+            let expectedPasswordHash = match?.hashedPassword ??
+                "$2a$10$N5NH4Xt9uj18GCd7W9Rl2eHrw8k6lhGpds5w389ux.bwZFMK5WSiq"
+
             guard try verifier.verify(
                 password: creds.password.makeBytes(),
                 matches: expectedPasswordHash.makeBytes()
                 ), let matchedUser = match else {
                     throw AuthenticationError.invalidCredentials
             }
+
             user = matchedUser
         } else {
             guard let match = try Self


### PR DESCRIPTION
I hope that this isn't unwelcome, but I noticed that when a user tried to login with a username that doesn't exist, the call immediately fails. This could potentially leak existence information to an attacker. In order to avoid this, I moved the `guard let hash = match.hashedPassword` to before the username check, so it always takes at least that long before the login fails.