### PR TITLE
Remove unnecessary Model conformance on Authenticatable

### DIFF
--- a/Sources/Authentication/Authenticatable.swift
+++ b/Sources/Authentication/Authenticatable.swift
@@ -4,4 +4,4 @@ import Vapor
 /// Capable of being authenticated.
 /// note: This protocol is extended by other protocols
 /// like PasswordAuthenticatable.
-public protocol Authenticatable: Model { }
+public protocol Authenticatable { }

--- a/Sources/Authentication/Basic/BasicAuthenticatable.swift
+++ b/Sources/Authentication/Basic/BasicAuthenticatable.swift
@@ -26,7 +26,7 @@ public protocol BasicAuthenticatable: Authenticatable {
     ) -> Future<Self?>
 }
 
-extension BasicAuthenticatable where Database: QuerySupporting {
+extension BasicAuthenticatable where Self: Model, Self.Database: QuerySupporting {
     /// See `BasicAuthenticatable.authenticate(...)`
     public static func authenticate(
         using basic: BasicAuthorization,

--- a/Sources/Authentication/Basic/BasicAuthenticationMiddleware.swift
+++ b/Sources/Authentication/Basic/BasicAuthenticationMiddleware.swift
@@ -48,7 +48,7 @@ public final class BasicAuthenticationMiddleware<A>: Middleware where A: BasicAu
     }
 }
 
-extension BasicAuthenticatable where Database: QuerySupporting {
+extension BasicAuthenticatable where Self: Model, Self.Database: QuerySupporting {
     /// Creates a basic auth middleware for this model.
     /// See `BasicAuthenticationMiddleware`.
     public static func basicAuthMiddleware(using verifier: PasswordVerifier) -> BasicAuthenticationMiddleware<Self> {

--- a/Sources/Authentication/Bearer/BearerAuthenticatable.swift
+++ b/Sources/Authentication/Bearer/BearerAuthenticatable.swift
@@ -3,7 +3,7 @@ import Bits
 import Fluent
 
 /// Authenticatable by `Bearer token` auth.
-public protocol BearerAuthenticatable: Authenticatable {
+public protocol BearerAuthenticatable: Authenticatable, Model {
     /// Key path to the token
     typealias TokenKey = WritableKeyPath<Self, String>
 
@@ -17,7 +17,7 @@ public protocol BearerAuthenticatable: Authenticatable {
     ) -> Future<Self?>
 }
 
-extension BearerAuthenticatable where Self: Model, Self.Database: QuerySupporting {
+extension BearerAuthenticatable where Database: QuerySupporting {
     /// See `BearerAuthenticatable.authenticate(...)`
     public static func authenticate(
         using bearer: BearerAuthorization,

--- a/Sources/Authentication/Bearer/BearerAuthenticatable.swift
+++ b/Sources/Authentication/Bearer/BearerAuthenticatable.swift
@@ -17,7 +17,7 @@ public protocol BearerAuthenticatable: Authenticatable {
     ) -> Future<Self?>
 }
 
-extension BearerAuthenticatable where Database: QuerySupporting {
+extension BearerAuthenticatable where Self: Model, Self.Database: QuerySupporting {
     /// See `BearerAuthenticatable.authenticate(...)`
     public static func authenticate(
         using bearer: BearerAuthorization,

--- a/Sources/Authentication/Password/PasswordAuthenticatable.swift
+++ b/Sources/Authentication/Password/PasswordAuthenticatable.swift
@@ -15,7 +15,7 @@ public protocol PasswordAuthenticatable: BasicAuthenticatable {
     ) -> Future<Self?>
 }
 
-extension PasswordAuthenticatable where Database: QuerySupporting {
+extension PasswordAuthenticatable where Self: Model, Self.Database: QuerySupporting {
     /// See `PasswordAuthenticatable.authenticate(...)`
     public static func authenticate(
         username: String,

--- a/Sources/Authentication/Persist/SessionAuthenticatable.swift
+++ b/Sources/Authentication/Persist/SessionAuthenticatable.swift
@@ -3,7 +3,7 @@ import Vapor
 
 /// Models conforming to this protocol can have their authentication
 /// status cached using `AuthenticationSessionsMiddleware`.
-public protocol SessionAuthenticatable: Authenticatable {
+public protocol SessionAuthenticatable: Authenticatable, Model {
     /// Create a serializable String representation for this model's ID.
     func makeSessionID() throws -> String
 

--- a/Sources/Authentication/Token/TokenAuthenticatable.swift
+++ b/Sources/Authentication/Token/TokenAuthenticatable.swift
@@ -16,7 +16,7 @@ public protocol TokenAuthenticatable: Authenticatable {
     ) -> Future<Self?>
 }
 
-extension TokenAuthenticatable where Self.Database: QuerySupporting {
+extension TokenAuthenticatable where Self: Model, Self.Database: QuerySupporting {
     /// See `TokenAuthenticatable.authenticate(...)`
     public static func authenticate(
         token: TokenType,

--- a/Sources/Authentication/Token/TokenAuthenticatable.swift
+++ b/Sources/Authentication/Token/TokenAuthenticatable.swift
@@ -31,7 +31,7 @@ extension TokenAuthenticatable where Self.Database: QuerySupporting {
 
 /// A token, related to a user, capable of being used with Bearer auth.
 /// See `TokenAuthenticatable`.
-public protocol Token: BearerAuthenticatable {
+public protocol Token: BearerAuthenticatable, Model {
     /// The User type that owns this token.
     associatedtype UserType: Model
         where UserType.Database == Database

--- a/Sources/Authentication/Token/TokenAuthenticatable.swift
+++ b/Sources/Authentication/Token/TokenAuthenticatable.swift
@@ -3,7 +3,7 @@ import Fluent
 import Vapor
 
 /// Authenticatable via a related token type.
-public protocol TokenAuthenticatable: Authenticatable {
+public protocol TokenAuthenticatable: Authenticatable, Model {
     /// The associated token type.
     associatedtype TokenType: Token
         where TokenType.UserType == Self
@@ -16,7 +16,7 @@ public protocol TokenAuthenticatable: Authenticatable {
     ) -> Future<Self?>
 }
 
-extension TokenAuthenticatable where Self: Model, Self.Database: QuerySupporting {
+extension TokenAuthenticatable where Database: QuerySupporting {
     /// See `TokenAuthenticatable.authenticate(...)`
     public static func authenticate(
         token: TokenType,
@@ -31,7 +31,7 @@ extension TokenAuthenticatable where Self: Model, Self.Database: QuerySupporting
 
 /// A token, related to a user, capable of being used with Bearer auth.
 /// See `TokenAuthenticatable`.
-public protocol Token: BearerAuthenticatable, Model {
+public protocol Token: BearerAuthenticatable {
     /// The User type that owns this token.
     associatedtype UserType: Model
         where UserType.Database == Database

--- a/Sources/Authentication/Token/TokenAuthenticatable.swift
+++ b/Sources/Authentication/Token/TokenAuthenticatable.swift
@@ -2,8 +2,13 @@ import Async
 import Fluent
 import Vapor
 
+/// Used to abstract `Model` conformance one degree away from `TokenAuthenticatable`
+/// in order to eliminate "redundant conformance" errors due to the
+/// `TokenType.UserType: Model` conformance requirement.
+public protocol AuthenticableModel: Authenticatable, Model {}
+
 /// Authenticatable via a related token type.
-public protocol TokenAuthenticatable: Authenticatable, Model {
+public protocol TokenAuthenticatable: AuthenticableModel {
     /// The associated token type.
     associatedtype TokenType: Token
         where TokenType.UserType == Self

--- a/Sources/Authentication/Token/TokenAuthenticationMiddleware.swift
+++ b/Sources/Authentication/Token/TokenAuthenticationMiddleware.swift
@@ -31,11 +31,11 @@ public final class TokenAuthenticationMiddleware<A>: Middleware where A: TokenAu
     }
 }
 
-extension TokenAuthenticatable {
+extension TokenAuthenticatable where Self: Model {
     /// Creates a basic auth middleware for this model.
     /// See `BasicAuthenticationMiddleware`.
     public static func tokenAuthMiddleware(
-        database: DatabaseIdentifier<Database>? = nil
+        database: DatabaseIdentifier<Self.Database>? = nil
     ) -> TokenAuthenticationMiddleware<Self> {
         return .init( bearer: TokenType.bearerAuthMiddleware())
     }

--- a/Sources/Authentication/Token/TokenAuthenticationMiddleware.swift
+++ b/Sources/Authentication/Token/TokenAuthenticationMiddleware.swift
@@ -31,11 +31,11 @@ public final class TokenAuthenticationMiddleware<A>: Middleware where A: TokenAu
     }
 }
 
-extension TokenAuthenticatable where Self: Model {
+extension TokenAuthenticatable {
     /// Creates a basic auth middleware for this model.
     /// See `BasicAuthenticationMiddleware`.
     public static func tokenAuthMiddleware(
-        database: DatabaseIdentifier<Self.Database>? = nil
+        database: DatabaseIdentifier<Database>? = nil
     ) -> TokenAuthenticationMiddleware<Self> {
         return .init( bearer: TokenType.bearerAuthMiddleware())
     }


### PR DESCRIPTION
Vapor's approach to authentication is designed to be flexible, and the ability to authenticate arbitrary classes on each `Request` via `try req.authenticated(T.self)` is powerful.

However, there is no logical or technical reason that `Authenticatable` classes must be `Model`'s. In fact, it's easy to imagine cases (e.g. God roles) where they shouldn't be.

This makes that possible.