### PR TITLE
Feature/infer auth type from context

### DIFF
--- a/Sources/Authentication/AuthenticationCache.swift
+++ b/Sources/Authentication/AuthenticationCache.swift
@@ -35,7 +35,7 @@ extension Request {
 
     /// Returns the authenticated instance of the supplied type.
     /// note: nil if no type has been authed, throws if there is a problem.
-    public func authenticated<A>(_ type: A.Type) throws -> A?
+    public func authenticated<A>(_ type: A.Type = A.self) throws -> A?
         where A: Authenticatable
     {
         let cache = try privateContainer.make(AuthenticationCache.self)
@@ -43,7 +43,7 @@ extension Request {
     }
 
     /// Unauthenticates an authenticatable type.
-    public func unauthenticate<A>(_ type: A.Type) throws
+    public func unauthenticate<A>(_ type: A.Type = A.self) throws
         where A: Authenticatable
     {
         let cache = try privateContainer.make(AuthenticationCache.self)
@@ -51,7 +51,7 @@ extension Request {
     }
 
     /// Returns true if the type has been authenticated.
-    public func isAuthenticated<A>(_ type: A.Type) throws -> Bool
+    public func isAuthenticated<A>(_ type: A.Type = A.self) throws -> Bool
         where A: Authenticatable
     {
         return try authenticated(A.self) != nil
@@ -60,7 +60,7 @@ extension Request {
     /// Returns an instance of the supplied type. Throws if no
     /// instance of that type has been authenticated or if there
     /// was a problem.
-    public func requireAuthenticated<A>(_ type: A.Type) throws -> A
+    public func requireAuthenticated<A>(_ type: A.Type = A.self) throws -> A
         where A: Authenticatable
     {
         guard let a = try authenticated(A.self) else {

--- a/Sources/Authentication/AuthenticationProvider.swift
+++ b/Sources/Authentication/AuthenticationProvider.swift
@@ -29,7 +29,5 @@ public final class AuthenticationProvider: Provider {
     }
 }
 
-
-
 /// A struct password verifier around bcrypt
 extension BCryptDigest: PasswordVerifier { }

--- a/Sources/Authentication/Basic/BasicAuthenticatable.swift
+++ b/Sources/Authentication/Basic/BasicAuthenticatable.swift
@@ -54,7 +54,6 @@ extension BasicAuthenticatable where Database: QuerySupporting {
     }
 }
 
-
 extension BasicAuthenticatable {
     /// Accesses the model's password
     public var basicPassword: String {

--- a/Sources/Authentication/Bearer/BearerAuthenticatable.swift
+++ b/Sources/Authentication/Bearer/BearerAuthenticatable.swift
@@ -32,7 +32,6 @@ extension BearerAuthenticatable where Database: QuerySupporting {
     }
 }
 
-
 extension BearerAuthenticatable {
     /// Accesses the model's token
     public var bearerToken: String {

--- a/Sources/Authentication/Token/TokenAuthenticatable.swift
+++ b/Sources/Authentication/Token/TokenAuthenticatable.swift
@@ -26,7 +26,6 @@ extension TokenAuthenticatable where Self.Database: QuerySupporting {
             return try token.authUser.get(on: connection).map(to: Self?.self) { $0 }
         }
     }
-
 }
 
 /// A token, related to a user, capable of being used with Bearer auth.


### PR DESCRIPTION
This PR allows
```swift
secured.get("me") { request -> U in
    try request.requireAuthenticated()
}
```

instead of
```swift
secured.get("me") { request -> U in
    try request.requireAuthenticated(U.self)
}
```
Same for the other authentication methods.