### PR TITLE
Removed unneeded try statements and redundant conformances

### DIFF
--- a/Sources/Authentication/Basic/BasicAuthenticatable.swift
+++ b/Sources/Authentication/Basic/BasicAuthenticatable.swift
@@ -22,19 +22,15 @@ public protocol BasicAuthenticatable: Authenticatable {
     static func authenticate(using basic: BasicAuthorization, verifier: PasswordVerifier, on connection: DatabaseConnectable) -> Future<Self?>
 }
 
-extension BasicAuthenticatable where Self: Model, Self.Database: QuerySupporting {
+extension BasicAuthenticatable where Self: Model {
     /// See `BasicAuthenticatable.authenticate(...)`
     public static func authenticate(using basic: BasicAuthorization, verifier: PasswordVerifier, on conn: DatabaseConnectable) -> Future<Self?> {
-        do {
-            return try Self.query(on: conn).filter(usernameKey == basic.username).first().map(to: Self?.self) { user in
-                guard let user = user, try verifier.verify(basic.password, created: user.basicPassword) else {
-                    return nil
-                }
-
-                return user
+        return Self.query(on: conn).filter(usernameKey == basic.username).first().map(to: Self?.self) { user in
+            guard let user = user, try verifier.verify(basic.password, created: user.basicPassword) else {
+                return nil
             }
-        } catch {
-            return conn.eventLoop.newFailedFuture(error: error)
+
+            return user
         }
     }
 }

--- a/Sources/Authentication/Basic/BasicAuthenticationMiddleware.swift
+++ b/Sources/Authentication/Basic/BasicAuthenticationMiddleware.swift
@@ -38,7 +38,7 @@ public final class BasicAuthenticationMiddleware<A>: Middleware where A: BasicAu
     }
 }
 
-extension BasicAuthenticatable where Self: Model, Self.Database: QuerySupporting {
+extension BasicAuthenticatable where Self: Model {
     /// Creates a basic auth middleware for this model.
     /// See `BasicAuthenticationMiddleware`.
     public static func basicAuthMiddleware(using verifier: PasswordVerifier) -> BasicAuthenticationMiddleware<Self> {

--- a/Sources/Authentication/Bearer/BearerAuthenticatable.swift
+++ b/Sources/Authentication/Bearer/BearerAuthenticatable.swift
@@ -14,14 +14,10 @@ public protocol BearerAuthenticatable: Authenticatable {
     static func authenticate(using bearer: BearerAuthorization, on connection: DatabaseConnectable) -> Future<Self?>
 }
 
-extension BearerAuthenticatable where Self: Model, Self.Database: QuerySupporting {
+extension BearerAuthenticatable where Self: Model {
     /// See `BearerAuthenticatable`.
     public static func authenticate(using bearer: BearerAuthorization, on conn: DatabaseConnectable) -> Future<Self?> {
-        do {
-            return try Self.query(on: conn).filter(tokenKey == bearer.token).first()
-        } catch {
-            return conn.eventLoop.newFailedFuture(error: error)
-        }
+        return Self.query(on: conn).filter(tokenKey == bearer.token).first()
     }
 }
 

--- a/Sources/Authentication/Password/PasswordAuthenticatable.swift
+++ b/Sources/Authentication/Password/PasswordAuthenticatable.swift
@@ -10,7 +10,7 @@ public protocol PasswordAuthenticatable: BasicAuthenticatable {
     static func authenticate(username: String, password: String, using verifier: PasswordVerifier, on conn: DatabaseConnectable) -> Future<Self?>
 }
 
-extension PasswordAuthenticatable where Self: Model, Self.Database: QuerySupporting {
+extension PasswordAuthenticatable where Self: Model {
     /// See `PasswordAuthenticatable`
     public static func authenticate(username: String, password: String, using verifier: PasswordVerifier, on conn: DatabaseConnectable ) -> Future<Self?> {
         return authenticate(

--- a/Sources/Authentication/Persist/SessionAuthenticatable.swift
+++ b/Sources/Authentication/Persist/SessionAuthenticatable.swift
@@ -23,11 +23,7 @@ extension Model where Self: SessionAuthenticatable, Self.ID: LosslessStringConve
 
     /// See `SessionAuthenticatable`.
     public static func authenticate(sessionID: Self.ID, on conn: DatabaseConnectable) -> Future<Self?> {
-        do {
-            return try find(sessionID, on: conn)
-        } catch {
-            return conn.eventLoop.newFailedFuture(error: error)
-        }
+        return find(sessionID, on: conn)
     }
 }
 

--- a/Sources/Authentication/Token/TokenAuthenticatable.swift
+++ b/Sources/Authentication/Token/TokenAuthenticatable.swift
@@ -30,15 +30,11 @@ extension Model where Self: Token, Self.UserType: Model {
 }
 
 extension TokenAuthenticatable
-    where Self: Model, Self.TokenType: Model, Self.Database: QuerySupporting, Self.TokenType.Database == Self.Database, Self.TokenType.UserIDType == Self.ID
+    where Self: Model, Self.TokenType: Model, Self.TokenType.Database == Self.Database, Self.TokenType.UserIDType == Self.ID
 {
     /// See `TokenAuthenticatable`.
     public static func authenticate(token: TokenType, on conn: DatabaseConnectable) -> Future<Self?> {
-        do {
-            return try token.authUser.get(on: conn).map { $0 }
-        } catch {
-            return conn.eventLoop.newFailedFuture(error: error)
-        }
+        return token.authUser.get(on: conn).map { $0 }
     }
 
     /// A relation to this user's tokens.
@@ -48,7 +44,7 @@ extension TokenAuthenticatable
 }
 
 extension Token
-    where Self: Model, Self.UserType: Model, Self.Database: QuerySupporting, Self.UserType.Database == Self.Database, Self.UserIDType == Self.UserType.ID
+    where Self: Model, Self.UserType: Model, Self.UserType.Database == Self.Database, Self.UserIDType == Self.UserType.ID
 {
     /// A relation to this token's owner.
     public var authUser: Parent<Self, UserType> {


### PR DESCRIPTION
Hi all,

I spent thirty seconds and removed some warnings from the project.

The warnings fell into two classes: Redundant conformance for `Self.Database: QuerySupporting` and needed `try` statements (which included the `do`/`catch` blocks).