### PR TITLE
Add original route to session before redirecting

### DIFF
--- a/Sources/Authentication/Persist/RedirectMiddleware.swift
+++ b/Sources/Authentication/Persist/RedirectMiddleware.swift
@@ -20,6 +20,7 @@ public struct RedirectMiddleware<A>: Middleware where A: Authenticatable {
         if try req.isAuthenticated(A.self) {
             return try next.respond(to: req)
         }
+        try req.session()["goto"] = req.http.urlString
         let redirect = req.redirect(to: path)
         return req.eventLoop.newSucceededFuture(result: redirect)
     }


### PR DESCRIPTION
Sometimes it's nice to redirect a user to the original requested route. So I added the requested route to the session before redirecting the unauthenticated user.

In the login controller, after successful login, it could be used like this:

```swift
let goto = try request.session()["goto"] ?? "/"
return request.redirect(to: goto)
```