### PR TITLE
session middleware short circuit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@
 Package.pins
 DerivedData/
 Package.resolved
+.swiftpm
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,5 @@
 // swift-tools-version:4.0
 import PackageDescription
-import Foundation
 
 let package = Package(
     name: "Auth",

--- a/Sources/Authentication/Persist/AuthenticationSessionsMiddleware.swift
+++ b/Sources/Authentication/Persist/AuthenticationSessionsMiddleware.swift
@@ -5,6 +5,12 @@ public final class AuthenticationSessionsMiddleware<A>: Middleware where A: Sess
 
     /// See Middleware.respond
     public func respond(to req: Request, chainingTo next: Responder) throws -> Future<Response> {
+        // if the user has already been authenticated
+        // by a previous middleware, continue
+        if try req.isAuthenticated(A.self) {
+            return try next.respond(to: req)
+        }
+        
         let future: Future<Void>
         if let aID = try req.authenticatedSession(A.self) {
             // try to find user with id from session


### PR DESCRIPTION
Adds a check to see if the user type has already been authenticated before checking sessions.

Fixes https://github.com/vapor/auth/issues/68