### PR TITLE
Fix Manifest Version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,4 @@
-// swift-tools-version:6.2
-// This should really be 6.2.3, but Xcode yet again has a bug
+// swift-tools-version:6.2.4
 import PackageDescription
 
 let extraSettings: [SwiftSetting] = [


### PR DESCRIPTION
Xcode had a bug that wouldn't read the Swift version, so we were unable to set the correct version (since we rely on memory flags). Now a version that works has been released, use it.
